### PR TITLE
Issues/#3

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -27,6 +27,9 @@ class AgendasController < ApplicationController
     if current_user == @team.owner || current_user == @agenda.user
       @agenda.destroy
       redirect_to dashboard_path, notice: I18n.t('views.messages.delete_agenda')
+      @team.users.each do |user|
+        AgendaDeleteMailer.agenda_delete_mail(user.email).deliver
+      end
     end
   end
 

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -21,6 +21,15 @@ class AgendasController < ApplicationController
     end
   end
 
+  def  destroy
+    @agenda = Agenda.find(params[:id])
+    @team = @agenda.team
+    if current_user == @team.owner || current_user == @agenda.user
+      @agenda.destroy
+      redirect_to dashboard_path, notice: I18n.t('views.messages.delete_agenda')
+    end
+  end
+
   private
 
   def set_agenda

--- a/app/mailers/agenda_delete_mailer.rb
+++ b/app/mailers/agenda_delete_mailer.rb
@@ -1,0 +1,8 @@
+class AgendaDeleteMailer < ApplicationMailer
+  default from: 'from@example.com'
+
+  def agenda_delete_mail(email)
+    @email = email
+    mail to: @email, subject: I18n.t('views.messages.delete_agenda')
+  end
+end

--- a/app/views/agenda_delete_mailer/agenda_delete_mail.html.erb
+++ b/app/views/agenda_delete_mailer/agenda_delete_mail.html.erb
@@ -1,0 +1,1 @@
+<h1><%= I18n.t('views.messages.delete_agenda') %></h1>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -31,11 +31,17 @@
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
             <a href="#" class="nav-link">
-              <i class="fa fa-circle-o nav-icon"></i>
-              <p>
-                <%= agenda.title %>
-                <i class="right fa fa-angle-left"></i>
-              </p>
+              
+              <table class="w-100">
+                <tr>
+                  <td class="w-auto"><i class="fa fa-circle-o nav-icon"></i></td>
+                  <td class="w-50"><%= agenda.title %></td>
+                  <% if current_user == agenda.team.owner || current_user == agenda.user %>
+                    <td class="w-25"><%= link_to I18n.t('views.button.delete'), agenda_path(agenda), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                  <% end %>
+                  <td class="w-auto"><i class="right fa fa-angle-left"></i></td>
+                </tr>
+              </table>
             </a>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,6 +216,7 @@ en:
   views:
     messages:
       create_agenda: 'Successfully created an agenda!'
+      delete_agenda: 'Delete the agenda'
       create_article: 'Successfully created an article!'
       update_article: 'Successfully updated the article!'
       assigned: 'Assigned!'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -206,6 +206,7 @@ ja:
   views:
     messages:
       create_agenda: 'アジェンダ作成に成功しました！'
+      delete_agenda: 'アジェンダを削除しました！'
       create_article: '記事作成に成功しました！'
       update_article: '記事更新に成功しました！'
       assigned: 'アサインしました！'

--- a/spec/mailers/agenda_delete_mailer_spec.rb
+++ b/spec/mailers/agenda_delete_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaDeleteMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_delete_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_delete_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_delete_mailer
+class AgendaDeleteMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
アジェンダの削除機能を実装しました。
詳細は下記の通りです。

- アジェンダの削除機能実装
  - タイトルの右側に削除ボタンを追加し、そこを押下するとアジェンダが削除される
  - アジェンダに紐づくアーティクルも一緒に削除される
  - 削除可能なのは、アジェンダの作者またはチームのリーダーのみ
  - 削除が実行されると、そのアジェンダに紐づくチームメンバー全員に通知メールが飛ぶ
  - 処理終了後は、ダッシュボードに遷移する

以上です。ご確認のほど、よろしくお願いいたします。